### PR TITLE
Fix `npm audit` security error in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "testcafe": "^0.9.0"
   },
   "dependencies": {
-    "handlebars": "4.1.2"
+    "handlebars": "^4.3.0"
   }
 }


### PR DESCRIPTION
The `handlebars` dependency in package.json is pinned to version "4.1.2". This PR updates package.json to a secure version of handlebars and allows updating the dependency with `npm audit fix` by specifying the version "^4.3.0".

```                                                          
                       === npm audit security report ===                        
                                                                                
┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.3.0                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ testcafe-reporter-nunit3 [dev]                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ testcafe-reporter-nunit3 > handlebars                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1164                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```