### PR TITLE
feat: include test metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Details of the NUnit format can be found at https://github.com/nunit/docs/wiki/T
 - Video and screenshot paths included as test case attachments.
 - Quarantine mode support: passing tests that failed at least once are marked as `Inconclusive` instead of `Passed`. The result of each run is specified as text appended to the error message.
 - Fails the test run (via a new failed test case) if the TestCafe process exits without all tests finishing. The provided xunit reporter emits a blank file in these scenarios.
+- Emits [fixture and test metadata](https://testcafe.io/documentation/403436/guides/intermediate-guides/metadata-and-filtering) as `<property>` elements.
 
 Error details for every failed quarantine run are not currently supported by the TestCafe Reporter API.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,10 +107,12 @@ class FixtureData {
   testCases: TestCaseData[];
   startTime: string;
   endTime?: string;
+  hasMetadata: boolean;
 
   constructor(public name: string, public path: string, private meta: Metadata) {
     this.startTime = new Date().toISOString();
     this.testCases = [];
+    this.hasMetadata = this.meta && Object.keys(this.meta).length > 0;
   }
 }
 
@@ -119,6 +121,7 @@ class TestCaseData {
   errorMessage: string;
   duration: number;
   hasFailureData: boolean;
+  hasMetadata: boolean;
   attachmentPaths?: string[];
   constructor(public name: string, public testRunInfo: TestRunInfo, private meta: Metadata, public formattedErrorMessage: string) {
     this.result = testRunInfo.skipped ? 'Skipped' : testRunInfo.errs.length > 0 ? 'Failed' : testRunInfo.unstable ? 'Inconclusive' : 'Passed';
@@ -146,6 +149,7 @@ class TestCaseData {
 
     this.duration = testRunInfo.durationMs / 1000;
     this.hasFailureData = !!this.errorMessage || !!this.formattedErrorMessage;
+    this.hasMetadata = this.meta && Object.keys(this.meta).length > 0;
   }
 }
 

--- a/src/template.handlebars
+++ b/src/template.handlebars
@@ -2,8 +2,22 @@
 <test-run id="2" name="TestCafe Tests" start-time="{{startTime}}" end-time="{{endTime}}">
     {{#fixtures}}
     <test-suite type="Assembly" name="{{name}}" start-time="{{startTime}}" end-time="{{endTime}}">
+        {{#if hasMetadata}}
+        <properties>
+            {{#each meta}}
+            <property name="{{@key}}" value="{{this}}" />
+            {{/each}}
+        </properties>
+        {{/if}}
         {{#testCases}}
         <test-case name="{{name}}" fullname="{{../name}} - {{name}}" result="{{result}}" duration="{{duration}}">
+            {{#if hasMetadata}}
+            <properties>
+                {{#each meta}}
+                <property name="{{@key}}" value="{{this}}" />
+                {{/each}}
+            </properties>
+            {{/if}}
             {{#if hasFailureData}}
             <failure>
                 <message>

--- a/test/__snapshots__/test-run-snapshots.spec.ts.snap
+++ b/test/__snapshots__/test-run-snapshots.spec.ts.snap
@@ -215,7 +215,14 @@ exports[`Regression testing  should match for the example data used by the offic
         </test-case>
     </test-suite>
     <test-suite type="Assembly" name="Third fixture" start-time="2077-03-14T03:14:15.926Z" end-time="2077-03-14T03:14:15.926Z">
+        <properties>
+            <property name="customFixtureMetadata" value="This is my favorite fixture." />
+        </properties>
         <test-case name="First test in third fixture" fullname="Third fixture - First test in third fixture" result="Failed" duration="74">
+            <properties>
+                <property name="customTestMetadata" value="This is my second favorite test." />
+                <property name="butWaitTheresMore" value="300ms" />
+            </properties>
             <failure>
                 <message>
                     <![CDATA[❌ - Error in test.before hook -

--- a/test/utils/reporter-test-calls.ts
+++ b/test/utils/reporter-test-calls.ts
@@ -142,7 +142,7 @@ export const sampleCalls: CallSequence = [
   },
   {
     method: 'reportFixtureStart',
-    args: ['Third fixture', './fixture3.js'],
+    args: ['Third fixture', './fixture3.js', { customFixtureMetadata: 'This is my favorite fixture.' }],
   },
   {
     method: 'reportTestDone',
@@ -168,6 +168,10 @@ export const sampleCalls: CallSequence = [
         unstable: true,
         screenshotPath: null,
       },
+      {
+        customTestMetadata: 'This is my second favorite test.',
+        butWaitTheresMore: '300ms'
+      }
     ],
   },
   {


### PR DESCRIPTION
Includes metadata defined on fixtures and test cases as properties within the report.